### PR TITLE
Add support for Firefox cookies

### DIFF
--- a/cmd/washcookies/config/config.go
+++ b/cmd/washcookies/config/config.go
@@ -73,6 +73,7 @@ import (
 	"github.com/creachadair/cookies"
 	"github.com/creachadair/cookies/bincookie"
 	"github.com/creachadair/cookies/chromedb"
+	"github.com/creachadair/cookies/firefox"
 )
 
 // OpenStore opens a cookie store for the specified path. The type of the
@@ -84,6 +85,9 @@ func OpenStore(path string) (cookies.Store, error) {
 	p := strings.ToLower(path)
 	if strings.Contains(p, "google") && filepath.Base(p) == "cookies" {
 		return chromedb.Open(path, nil)
+	}
+	if strings.Contains(p, "firefox") && filepath.Base(p) == "cookies.sqlite" {
+		return firefox.Open(path, nil)
 	}
 	return nil, errors.New("unknown file type")
 }

--- a/docs/chrome-encrypted-cookies.md
+++ b/docs/chrome-encrypted-cookies.md
@@ -56,7 +56,7 @@ An encrypted value consists of a data packet that is encrypted with AES-128 in C
 | n     | value                  | Payload (encrypted)             |
 | p     | padding                | Padding (encrypted), 1–16 bytes |
 
-The encrypted portion of the packet (n+ p) contains a multiple of 16 bytes. If n is a multiple of 16, p = 16; otherwise 1 ≤ p ≤ 15.
+The encrypted portion of the packet (n + p) contains a multiple of 16 bytes. If n is a multiple of 16, p = 16; otherwise 1 ≤ p ≤ 15.
 
 ### Padding
 
@@ -71,3 +71,7 @@ Encryption and decryption are performed using AES-128 in cipher-block chaining (
 ## Key Generation
 
 The 16-byte AES-128 encryption key is generated using the [PBKDF2 (RFC 2898)](https://tools.ietf.org/html/rfc2898) algorithm from a user-provided passphrase. The key generation salt is the fixed string `saltysalt`. On macOS, Chrome uses 1003 iterations of the key generation algorithm; on Linux it uses 1 iteration. I don't know what it does on Windows.
+
+On macOS, Chrome stores the encryption passphrase in the user's login keychain under "Chrome Safe Storage". The passphrase is base64-encoded but is used directly in its base64-encoded form.
+
+Older versions of Chrome and Chromium on Linux used the fixed passphrase `peanuts`, but more recent versions use the Gnome keyring.

--- a/firefox/firefox.go
+++ b/firefox/firefox.go
@@ -1,0 +1,188 @@
+// Copyright 2023 Michael J. Fromberger. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package firefox supports reading and modifying a Firefox cookies database.
+package firefox
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/creachadair/cookies"
+)
+
+// Open opens the Firefox cookie database at the specified path.
+// If opts == nil, default options are used.
+func Open(path string, opts *Options) (*Store, error) {
+	db, err := sql.Open(opts.driver(), path)
+	if err != nil {
+		return nil, err
+	}
+	return &Store{db: db}, nil
+}
+
+// Options are optional settings for a Store.
+// A nil *Options is ready for use with default settings.
+type Options struct{}
+
+func (*Options) driver() string { return "sqlite" }
+
+// A Store connects to a collection of cookies storeed in an SQLite database
+// using the Firefox cookie schema.
+type Store struct {
+	db *sql.DB
+}
+
+// Scan implements part of the cookies.Store interface.
+func (s *Store) Scan(f cookies.ScanFunc) error {
+	cs, err := s.readCookies()
+	if err != nil {
+		return err
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	for _, c := range cs {
+		act, err := f(c)
+		if err != nil {
+			return err
+		}
+		switch act {
+		case cookies.Keep:
+			continue
+
+		case cookies.Update:
+			if err := s.writeCookie(tx, c); err != nil {
+				return err
+			}
+
+		case cookies.Discard:
+			if err := s.dropCookie(tx, c); err != nil {
+				return err
+			}
+
+		default:
+			return fmt.Errorf("unknown action %v", act)
+		}
+	}
+	return tx.Commit()
+}
+
+// Commit implements part of the cookies.Store interface.
+func (s *Store) Commit() error { return nil }
+
+type Cookie struct {
+	cookies.C
+
+	id int64
+}
+
+// Get implements part of the cookies.Editor interface.
+func (c *Cookie) Get() cookies.C { return c.C }
+
+// Set implements part of the cookies.Editor interface.
+func (c *Cookie) Set(o cookies.C) error { c.C = o; return nil }
+
+func (s *Store) readCookies() ([]*Cookie, error) {
+	rows, err := s.db.Query(`SELECT ` +
+		`id, name, value, host, path, expiry, creationTime, isSecure, isHttpOnly, sameSite ` +
+		`FROM moz_cookies`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var cs []*Cookie
+	for rows.Next() {
+		var rowID, expiry, creationTime, sameSite int64
+		var isSecure, isHTTPOnly bool
+		var name, value, host, path string
+
+		if err := rows.Scan(&rowID, &name, &value, &host, &path, &expiry, &creationTime,
+			&isSecure, &isHTTPOnly, &sameSite); err != nil {
+			return nil, err
+		}
+
+		cs = append(cs, &Cookie{
+			C: cookies.C{
+				Name:    name,
+				Value:   value,
+				Domain:  host,
+				Path:    path,
+				Expires: time.Unix(expiry, 0).UTC(),
+				Created: time.UnixMicro(creationTime).UTC(),
+				Flags: cookies.Flags{
+					Secure:   isSecure,
+					HTTPOnly: isHTTPOnly,
+				},
+				SameSite: decodeSitePolicy(sameSite),
+			},
+			id: rowID,
+		})
+	}
+	return cs, nil
+}
+
+func (s *Store) dropCookie(tx *sql.Tx, c *Cookie) error {
+	_, err := tx.Exec(`DELETE FROM moz_cookies WHERE id = ?`, c.id)
+	return err
+}
+
+func (s *Store) writeCookie(tx *sql.Tx, c *Cookie) error {
+	_, err := tx.Exec(`UPDATE moz_cookies SET `+
+		`name = ?, value = ?, host = ?, path = ?, expiry = ?, creationTime = ?, `+
+		`isSecure = ?, isHttpOnly = ?, sameSite = ? `+
+		`WHERE id = ?`,
+		c.Name, c.Value, c.Domain, c.Path, c.Expires.Unix(), c.Created.UnixMicro(),
+		boolToInt(c.Flags.Secure), boolToInt(c.Flags.HTTPOnly), encodeSitePolicy(c.SameSite),
+		c.id,
+	)
+	return err
+}
+
+func boolToInt(ok bool) int {
+	if ok {
+		return 1
+	}
+	return 0
+}
+
+func decodeSitePolicy(ss int64) cookies.SameSite {
+	switch ss {
+	case 0:
+		return cookies.None
+	case 1:
+		return cookies.Lax
+	case 2:
+		return cookies.Strict
+	default:
+		return cookies.Unknown
+	}
+}
+
+func encodeSitePolicy(ss cookies.SameSite) int {
+	switch ss {
+	case cookies.Lax:
+		return 1
+	case cookies.Strict:
+		return 2
+	default:
+		return 0 // for Firefox this means "None"
+	}
+}

--- a/firefox/firefox_test.go
+++ b/firefox/firefox_test.go
@@ -1,0 +1,61 @@
+// Copyright 2023 Michael J. Fromberger. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package firefox_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/creachadair/cookies"
+	"github.com/creachadair/cookies/firefox"
+
+	_ "modernc.org/sqlite"
+)
+
+var (
+	inputFile = flag.String("input", "", "Input Firefox cookie database")
+)
+
+func TestManual(t *testing.T) {
+	if *inputFile == "" {
+		t.Skip("Skipping test since no -input is specified")
+	}
+	s, err := firefox.Open(*inputFile, nil)
+	if err != nil {
+		t.Fatalf("Opening database: %v", err)
+	}
+
+	var numCookies int
+	if err := s.Scan(func(e cookies.Editor) (cookies.Action, error) {
+		numCookies++
+		c := e.Get()
+		t.Logf("-- Cookie %d:\n"+
+			"  domain=%q name=%q value=%q\n"+
+			"  secure=%v http_only=%v samesite=%v\n"+
+			"  created=%v | expires=%v",
+			numCookies,
+			c.Domain, c.Name, c.Value,
+			c.Flags.Secure, c.Flags.HTTPOnly, c.SameSite,
+			c.Created, c.Expires)
+		return cookies.Keep, nil
+	}); err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if err := s.Commit(); err != nil {
+		t.Fatalf("Commit failed; %v", err)
+	}
+
+	t.Logf("Found %d cookies", numCookies)
+}


### PR DESCRIPTION
Firefox uses a SQLite database similar to Chrome, but with somewhat less
pathological dark patterns to defend the ad business (e.g., encrypted cookies).

- firefox: add support for reading/editing Firefox cookies
- docs: update Chrome info from the public gist
- cmd/washcookies: add support for Firefox cookies
